### PR TITLE
Catch serialization bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.5
+* Mocked environments will serialize and deserialize JSON message.
+
 # 0.1.2
 * RPC support for RabbitMQ
 * Deprecated mocked queues `rabbit/queues` in favor of `mocks/queues`

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject microscope/rabbit "0.1.4"
+(defproject microscope/rabbit "0.1.5"
   :description "RabbitMQ implementation for Microscope"
   :url "https://github.com/acessocard/microscope"
   :license {:name "Eclipse Public License"

--- a/test/microscope/rabbit/queue_test.clj
+++ b/test/microscope/rabbit/queue_test.clj
@@ -154,6 +154,17 @@
       (-> @mocks/queues :test-result :messages deref)
       => (just [(contains {:payload "MESSAGE"})])))
 
+  (fact "checks if message is json-serializable"
+    (components/mocked
+      (a-function (rabbit/queue "test"))
+      (io/send! (:test @mocks/queues) {:payload {:dt #inst "2010-10-20T10:00:00Z"}})
+      (->> @mocks/queues :test :messages deref (map :payload))
+      => [{:dt "2010-10-20T10:00:00Z"}]
+
+      (io/send! (:test @mocks/queues) {:payload {:obj (Object.)}}) => throws
+      (->> @mocks/queues :test :messages deref (map :payload))
+      => [{:dt "2010-10-20T10:00:00Z"}]))
+
   (fact "ignores delayed messages"
     (components/mocked
       (a-function (rabbit/queue "test" :delayed true))


### PR DESCRIPTION
With mocked environment, when we send a message to a queue, it was just copying the message as-is and passing it to the mocked queue.

With this PR, we'll serialize and de-serialize the message. This will catch:

1. Bugs from objects we can't serialize
1. Info lost in serialization (date-times, instant, bigdecimals)
1. Strange things like lists-vectors-lazyseqs