### PR TITLE
Normalize logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.2.0
+* Removed deprecated `rabbit/queues`
+* Normalized logs to use our schema (meta and payload, as strings)
+
 # 0.1.5
 * Add message's queue name into log metadata
 * Remove "msg" root key from log metadata

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject microscope/rabbit "0.1.5"
+(defproject microscope/rabbit "0.2.0"
   :description "RabbitMQ implementation for Microscope"
   :url "https://github.com/acessocard/microscope"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :license {:name "MIT License"
+            :url "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [com.novemberain/langohr "3.6.1"]
-                 [microscope "0.1.4"]]
+                 [microscope "0.2.0-SNAPSHOT"]]
 
   :profiles {:dev {:src-paths ["dev"]
                    :dependencies [[midje "1.8.3"]]

--- a/src/microscope/rabbit/mocks.clj
+++ b/src/microscope/rabbit/mocks.clj
@@ -23,7 +23,7 @@
           (swap! (:messages queue) conj {:payload json-payload
                                          :meta (assoc meta :cid cid)})))))
 
-  (ack! [_ {:keys [meta]}])
+  (ack! [_ _])
   (reject! [self msg ex])
   (log-message [_ _ _]))
 

--- a/src/microscope/rabbit/queue.clj
+++ b/src/microscope/rabbit/queue.clj
@@ -180,8 +180,6 @@
     (route-exchange channel name (or (:route-to opts) [name]) opts)
     (->Queue channel name (:max-retries opts) nil)))
 
-(def ^:deprecated queues mocks/queues)
-
 (defn queue
   "Defines a new RabbitMQ's connection. Valid params are `:exclusive`, `:auto-delete`,
 `:durable` and `:ttl`, all from Rabbit's documentation. We support additional

--- a/src/microscope/rabbit/queue.clj
+++ b/src/microscope/rabbit/queue.clj
@@ -98,9 +98,11 @@
   (ack! [_ {:keys [meta]}]
         (basic/ack channel (:delivery-tag meta)))
 
-  (log-message [_ logger msg]
-    (let [data (assoc msg :queue-name name)]
-      (apply log/info logger "Processing message" (flatten (seq data)))))
+  (log-message [_ logger {:keys [payload meta]}]
+    (let [meta (assoc meta :queue name)]
+      (log/info logger "Processing message"
+                :payload (io/serialize-msg payload)
+                :meta (io/serialize-msg meta))))
 
   (reject! [self msg _]
            (let [meta (:meta msg)

--- a/src/microscope/rabbit/rpc.clj
+++ b/src/microscope/rabbit/rpc.clj
@@ -23,8 +23,10 @@
   (ack! [_ {:keys [meta]}]
         (basic/ack channel (:delivery-tag meta)))
 
-  (log-message [_ logger msg]
-               (log/info logger "Processing RPC message" :msg msg))
+  (log-message [_ logger {:keys [payload meta]}]
+    (log/info logger "Processing RPC message"
+              :payload (io/serialize-msg payload)
+              :meta (io/serialize-msg meta)))
 
   (reject! [self msg _]
            (basic/reject channel (-> msg :meta :delivery-tag) false))

--- a/src/microscope/rabbit/rpc.clj
+++ b/src/microscope/rabbit/rpc.clj
@@ -12,10 +12,10 @@
 (defrecord Queue [channel name cid original-meta]
   io/IO
   (listen [self function]
-          (let [callback (partial rabbit/callback-payload function 1 self)]
+          (let [callback #(rabbit/callback-payload function self %2 %3)]
             (consumers/subscribe channel name callback)))
 
-  (send! [_ {:keys [payload meta] :or {meta {}}}]
+  (send! [_ {:keys [payload _]}]
          (basic/publish channel "" (:reply-to original-meta)
                         (io/serialize-msg payload)
                         (select-keys original-meta [:correlation-id])))
@@ -35,7 +35,7 @@
 
 (defn- real-rabbit-queue [name opts]
   (let [opts (merge rabbit/default-queue-params opts)
-        [connection channel] (rabbit/connection-to-queue name (:prefetch-count opts))]
+        [_ channel] (rabbit/connection-to-queue name (:prefetch-count opts))]
     (rabbit/define-queue channel name opts)
     (->Queue channel name nil nil)))
 


### PR DESCRIPTION
RabbitMQ now logs only strings `payload` and `meta` keys.

This means less errors for ElasticSearch to handle.